### PR TITLE
update: add endOfLine rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,17 @@
 {
-  "extends": ["next/core-web-vitals", "plugin:prettier/recommended"],
-  "plugins": ["prettier"],
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:prettier/recommended"
+  ],
+  "plugins": [
+    "prettier"
+  ],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Изменено значение правила "endOfLine" в конфигурации линтера Prettier на "auto", чтобы установить единую кодировку переноса строки в проекте.